### PR TITLE
Change baseUrl to work nicely in local development

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,7 +17,7 @@ const config = {
   url: 'https://your-docusaurus-test-site.com',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/Practical-Machine-Learning',
+  baseUrl: process.env.GITHUB_ACTIONS ? '/Practical-Machine-Learning' : '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
- 現在の設定だとローカル上で正しくベース URL が表示されないので、GitHub Action 以外でベース URL がルートになるように修正しました。